### PR TITLE
mod: updated to reflect new plan_id requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ resource "azurerm_palo_alto_next_generation_firewall_virtual_hub_local_rulestack
     virtual_hub_id               = azurerm_virtual_hub.vhub-eastus.id
     network_virtual_appliance_id = azurerm_palo_alto_virtual_network_appliance.nva-eastus.id
   }
+
+  plan_id = "panw-cngfw-payg"
 }
 ```
 Next, create a Cloud NGFW managed by Panorama. You are required to have a Panorama instance with the Azure plugin installed to generate the Registration String.
@@ -169,6 +171,7 @@ resource "azurerm_palo_alto_next_generation_firewall_virtual_hub_panorama" "cngf
     network_virtual_appliance_id = azurerm_palo_alto_virtual_network_appliance.nva-westeu.id
   }
 
+  plan_id = "panw-cngfw-payg"
   panorama_base64_config = var.panorama-string
 }
 ```

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">=4.18.0" # New plan_id introduced at this version
+    }
+  }
+}
+
 provider "azurerm" {
     features {}
 }
@@ -76,6 +85,8 @@ resource "azurerm_palo_alto_next_generation_firewall_virtual_hub_local_rulestack
     virtual_hub_id               = azurerm_virtual_hub.vhub-westeurope.id
     network_virtual_appliance_id = azurerm_palo_alto_virtual_network_appliance.nva-westeurope.id
   }
+
+  plan_id = "panw-cngfw-payg"
 }
 
 resource "azurerm_palo_alto_next_generation_firewall_virtual_hub_panorama" "cngfw-eastus" {
@@ -88,6 +99,8 @@ resource "azurerm_palo_alto_next_generation_firewall_virtual_hub_panorama" "cngf
     virtual_hub_id               = azurerm_virtual_hub.vhub-eastus.id
     network_virtual_appliance_id = azurerm_palo_alto_virtual_network_appliance.nva-eastus.id
   }
+
+  plan_id = "panw-cngfw-payg"
 
   panorama_base64_config = var.panorama-string
 }


### PR DESCRIPTION
Updated with the following to reflect the latest changes to the provider and in the Azure backend:
[plan_id](https://registry.terraform.io/providers/hashicorp/azurerm/4.18.0/docs/resources/palo_alto_next_generation_firewall_virtual_network_panorama#plan_id-8) - The billing plan ID as published by Liftr.PAN. Defaults to panw-cngfw-payg, however, needs to be called out still currently in your resource block, otherwise will fail.